### PR TITLE
Proposed Revisions

### DIFF
--- a/docs/basicusage.rst
+++ b/docs/basicusage.rst
@@ -26,7 +26,7 @@ Don't set the sleep too low, or you may run into rate limits or other issues.
 If in doubt, keep this above 900 (fifteen minutes).
 
 .. _source:
-Next, add your sources. To configure the source, you should give it a unique name like ``[source:inquest-rss]``.  Each source uses a module like twitter, rss, or csv.  Choose the module for the expected format of the source data.  For easy testing, we'll use an :ref:`RSS <rss-source>` source and a :ref:`CSV <csv-operator>` operator:
+Next, add your sources. To configure the source, you should give it a unique name like ``[source:inquest-rss]``.  Each source uses a module like twitter, rss, or sqs.  Choose the module for the expected format of the source data.  For easy testing, we'll use an :ref:`RSS <rss-source>` source and a :ref:`CSV <csv-operator>` operator:
 
 .. code-block:: ini
 
@@ -37,7 +37,7 @@ Next, add your sources. To configure the source, you should give it a unique nam
     feed_type = messy
 
 .. _operator:
-Similarly the operators are identify a name, a module, and a file for output.  The module specifies the format of the output.
+Similarly the operators are identify a name, a module, and an optional file for output.  The module specifies the format of the output.
 .. code-block:: ini
 
     [operator:csv]
@@ -62,7 +62,7 @@ It should write out a ``output.csv`` file that looks something like this:
 
 Assuming you are running in daemon mode, ThreatIngestor will continue to check
 the blog and append new artifacts to the CSV as it finds them.  For further configuration,
-continue to the Standard Use Case section (standard-case_) or see the detailed sections about
+continue to the Standard Case section (standard-case_) or see the detailed sections about
 :ref:`source plugins <source-plugins>`, and :ref:`operator <operator-plugins>`.
 
 

--- a/docs/basicusage.rst
+++ b/docs/basicusage.rst
@@ -26,9 +26,7 @@ Don't set the sleep too low, or you may run into rate limits or other issues.
 If in doubt, keep this above 900 (fifteen minutes).
 
 .. _source:
-.. _operator:
-Next, add your sources and operators. For easy testing, we'll use an :ref:`RSS
-<rss-source>` source and a :ref:`CSV <csv-operator>` operator:
+Next, add your sources. To configure the source, you should give it a unique name like ``[source:inquest-rss]``.  Each source uses a module like twitter, rss, or csv.  Choose the module for the expected format of the source data.  For easy testing, we'll use an :ref:`RSS <rss-source>` source and a :ref:`CSV <csv-operator>` operator:
 
 .. code-block:: ini
 
@@ -37,6 +35,10 @@ Next, add your sources and operators. For easy testing, we'll use an :ref:`RSS
     saved_state = 
     url = http://blog.inquest.net/atom.xml
     feed_type = messy
+
+.. _operator:
+Similarly the operators are identify a name, a module, and a file for output.  The module specifies the format of the output.
+.. code-block:: ini
 
     [operator:csv]
     module = csv
@@ -60,11 +62,11 @@ It should write out a ``output.csv`` file that looks something like this:
 
 Assuming you are running in daemon mode, ThreatIngestor will continue to check
 the blog and append new artifacts to the CSV as it finds them.  For further configuration,
-continue to the Standard Use Case section (standard-use-case_) or see the detailed sections about
+continue to the Standard Use Case section (standard-case_) or see the detailed sections about
 :ref:`source plugins <source-plugins>`, and :ref:`operator <operator-plugins>`.
 
 
-.. _standard-use-case:
+.. _standard-case:
 
 Standard Case
 -------------

--- a/docs/basicusage.rst
+++ b/docs/basicusage.rst
@@ -19,7 +19,7 @@ First create a new ``config.ini`` file, and add the ``[main]`` section:
     daemon = true
     sleep = 900
 
-.. _mode:
+.. _mode
 To configure mode, configure ``daemon``. If you set ``daemon`` to ``true``, ThreatIngestor will watch
 your sources in a loop; set it to ``false`` to run manually, or via cron or some other scheduler. 
 Set ``sleep`` to the number of seconds to wait between each check - this will be ignored if you disable daemon mode.

--- a/docs/basicusage.rst
+++ b/docs/basicusage.rst
@@ -9,7 +9,7 @@ Minimal Case
 ------------
 
 For the most basic ThreatIngestor setup, you will want to configure at least
-one source_, one operator_, and the daemon_.
+one source_, one operator_, and set the mode (as shown below).
 
 First create a new ``config.ini`` file, and add the ``[main]`` section:
 
@@ -19,10 +19,9 @@ First create a new ``config.ini`` file, and add the ``[main]`` section:
     daemon = true
     sleep = 900
 
-.. _daemon:
-Configure ``daemon`` to run continuously or manually. If you set ``daemon`` to ``true``, ThreatIngestor will watch
+Configure ThreatIngestor to run continuously or manually. If you set ``daemon`` to ``true``, ThreatIngestor will watch
 your sources in a loop; set it to ``false`` to run manually, or via cron or some other scheduler. 
-Set ``sleep`` to the number of seconds to wait between each check - this will be ignored if you daemon mode is false.
+Set ``sleep`` to the number of seconds to wait between each check - this will be ignored if ``daemon`` is set ``false``.
 Don't set the sleep too low, or you may run into rate limits or other issues.
 If in doubt, keep this above 900 (fifteen minutes).
 

--- a/docs/basicusage.rst
+++ b/docs/basicusage.rst
@@ -9,8 +9,7 @@ Minimal Case
 ------------
 
 For the most basic ThreatIngestor setup, you will want to configure at least
-one :ref:`source <source-plugins>`, one :ref:`operator <operator-plugins>`, and
-whether you want to run in daemon or job mode.
+one :ref:`source <source-plugins>`, one :ref:`operator <operator-plugins>`, and choose your mode (daemon or job).
 
 First create a new ``config.ini`` file, and add the ``[main]`` section:
 

--- a/docs/basicusage.rst
+++ b/docs/basicusage.rst
@@ -9,7 +9,7 @@ Minimal Case
 ------------
 
 For the most basic ThreatIngestor setup, you will want to configure at least
-one :ref:`source <source-plugins>`, one :ref:`operator <operator-plugins>`, and choose your mode (daemon or job).
+one :ref:`source <source-plugins>`, one :ref:`operator <operator-plugins>`, and mode_.
 
 First create a new ``config.ini`` file, and add the ``[main]`` section:
 
@@ -19,10 +19,10 @@ First create a new ``config.ini`` file, and add the ``[main]`` section:
     daemon = true
     sleep = 900
 
-Set ``daemon`` to ``true`` if you want ThreatIngestor to constantly watch
-your sources in a loop; set it to ``false`` if you want to run it manually,
-or via cron or some other scheduler. Set ``sleep`` to the number of seconds
-to wait between each check - this will be ignored if you disable daemon mode.
+.. _mode:
+To configure mode, configure ``daemon``. If you set ``daemon`` to ``true``, ThreatIngestor will watch
+your sources in a loop; set it to ``false`` to run manually, or via cron or some other scheduler. 
+Set ``sleep`` to the number of seconds to wait between each check - this will be ignored if you disable daemon mode.
 Don't set the sleep too low, or you may run into rate limits or other issues.
 If in doubt, keep this above 900 (fifteen minutes).
 

--- a/docs/basicusage.rst
+++ b/docs/basicusage.rst
@@ -9,7 +9,7 @@ Minimal Case
 ------------
 
 For the most basic ThreatIngestor setup, you will want to configure at least
-one :ref:`source <source-plugins>`, one :ref:`operator <operator-plugins>`, and daemon_.
+one source_, one operator_, and the daemon_.
 
 First create a new ``config.ini`` file, and add the ``[main]`` section:
 
@@ -26,6 +26,8 @@ Set ``sleep`` to the number of seconds to wait between each check - this will be
 Don't set the sleep too low, or you may run into rate limits or other issues.
 If in doubt, keep this above 900 (fifteen minutes).
 
+.. _source:
+.. _operator:
 Next, add your sources and operators. For easy testing, we'll use an :ref:`RSS
 <rss-source>` source and a :ref:`CSV <csv-operator>` operator:
 
@@ -56,8 +58,12 @@ It should write out a ``output.csv`` file that looks something like this:
     URL,http://purl.org/dc/elements/1.1,http://blog.inquest.net/blog/2018/02/07/cve-2018-4878-adobe-flash-0day-itw/,"\n On February 1st, Adobe published bulletin  APSA18-01  for CVE-2018-4878 describing a use-after-free (UAF) vulnerability affecting Flash ve..."
     ...
 
+
 Assuming you are running in daemon mode, ThreatIngestor will continue to check
-the blog and append new artifacts to the CSV as it finds them.
+the blog and append new artifacts to the CSV as it finds them.  For further configuration,
+continue to the Standard Use Case section (standard-use-case_) or see the detailed sections about
+:ref:`source plugins <source-plugins>`, and :ref:`operator <operator-plugins>`.
+
 
 .. _standard-use-case:
 

--- a/docs/basicusage.rst
+++ b/docs/basicusage.rst
@@ -19,7 +19,7 @@ First create a new ``config.ini`` file, and add the ``[main]`` section:
     daemon = true
     sleep = 900
 
-.. _mode
+.. _mode:
 To configure mode, configure ``daemon``. If you set ``daemon`` to ``true``, ThreatIngestor will watch
 your sources in a loop; set it to ``false`` to run manually, or via cron or some other scheduler. 
 Set ``sleep`` to the number of seconds to wait between each check - this will be ignored if you disable daemon mode.

--- a/docs/basicusage.rst
+++ b/docs/basicusage.rst
@@ -9,7 +9,7 @@ Minimal Case
 ------------
 
 For the most basic ThreatIngestor setup, you will want to configure at least
-one :ref:`source <source-plugins>`, one :ref:`operator <operator-plugins>`, and mode_.
+one :ref:`source <source-plugins>`, one :ref:`operator <operator-plugins>`, and daemon_.
 
 First create a new ``config.ini`` file, and add the ``[main]`` section:
 
@@ -19,10 +19,10 @@ First create a new ``config.ini`` file, and add the ``[main]`` section:
     daemon = true
     sleep = 900
 
-.. _mode:
-To configure mode, configure ``daemon``. If you set ``daemon`` to ``true``, ThreatIngestor will watch
+.. _daemon:
+Configure ``daemon`` to run continuously or manually. If you set ``daemon`` to ``true``, ThreatIngestor will watch
 your sources in a loop; set it to ``false`` to run manually, or via cron or some other scheduler. 
-Set ``sleep`` to the number of seconds to wait between each check - this will be ignored if you disable daemon mode.
+Set ``sleep`` to the number of seconds to wait between each check - this will be ignored if you daemon mode is false.
 Don't set the sleep too low, or you may run into rate limits or other issues.
 If in doubt, keep this above 900 (fifteen minutes).
 

--- a/docs/plugins/source.rst
+++ b/docs/plugins/source.rst
@@ -3,11 +3,11 @@
 Source Plugins
 ==============
 
-Source plugins handle artifact import. All source plugins maintain state
-between runs, allowing them to skip previously processed tweets, blog posts,
-etc and get right to work finding new indicators.
+Source plugins handle artifact import. Artifacts include tweets, blog posts, etc.
+All source plugins maintain state between runs, allowing them to skip previously
+processed artifacts and get right to work finding new indicators.
 
-To add an source to your configuration file, include a section like this:
+To add a source to your configuration file, include a section like this:
 
 .. code-block:: ini
 

--- a/docs/plugins/source.rst
+++ b/docs/plugins/source.rst
@@ -3,7 +3,8 @@
 Source Plugins
 ==============
 
-Source plugins handle artifact import. Artifacts include tweets, blog posts, etc.
+For each source specified, ``ThreatIngestor`` handles artifact import. Sources may link to Twitter, Blogs, etc.
+Artifacts are imported from those sources and could include URLs, IP Addresses, YARA Signatures, etc.
 All source plugins maintain state between runs, allowing them to skip previously
 processed artifacts and get right to work finding new indicators.
 


### PR DESCRIPTION
@rshipp I think this is the only proposed revision I can make for the time being.  My thinking is that the basic use case should keep things simple.  The links at the top sending them to the plugins were a bit of overload before the user has seen how to configure the source and operator on a simpler level.  I moved the links to the plugins to the bottom of the section and also mentioned moving onto the next section for more information.  I hope these suggestions are useful.  I atempted to use the [internal hyperlink](http://docutils.sourceforge.net/docs/user/rst/quickref.html#internal-hyperlink-targets) syntax to move the user through the basic usage section.  I hope that it works.  