### PR TITLE
Fix operator name handling

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -164,8 +164,8 @@ class TestConfig(unittest.TestCase):
         }
 
         expected_operators = [
-            ('test-one', threatingestor.operators.csv.Plugin, {'filename': 'output.csv', 'name': 'test-one'}),
-            ('test-three', threatingestor.operators.csv.Plugin, {'filename': 'output.csv','name': 'test-three'}),
+            ('test-one', threatingestor.operators.csv.Plugin, {'filename': 'output.csv'}),
+            ('test-three', threatingestor.operators.csv.Plugin, {'filename': 'output.csv'}),
         ]
         self.assertEqual(self.config.operators(), expected_operators)
 
@@ -193,8 +193,8 @@ class TestConfig(unittest.TestCase):
         }
 
         expected_operators = [
-            ('test-one', threatingestor.operators.csv.Plugin, {'filename': 'output.csv', 'name': 'test-one', 'token': 'mytoken'}),
-            ('test-three', threatingestor.operators.csv.Plugin, {'filename': 'output.csv','name': 'test-three'}),
+            ('test-one', threatingestor.operators.csv.Plugin, {'filename': 'output.csv', 'token': 'mytoken'}),
+            ('test-three', threatingestor.operators.csv.Plugin, {'filename': 'output.csv'}),
         ]
 
         self.assertEqual(self.config.operators(), expected_operators)
@@ -216,7 +216,6 @@ class TestConfig(unittest.TestCase):
 
         expected_operators = [
             ('test-one', threatingestor.operators.csv.Plugin, {
-                'name': 'test-one',
                 'filename': 'output.csv',
                 'allowed_sources': ["mysource", "myothersource"],
                 'filter_string': '([^\.]google.com$|google.com[^/])',

--- a/threatingestor/config.py
+++ b/threatingestor/config.py
@@ -18,6 +18,7 @@ INTERNAL_OPTIONS = [
 ARTIFACT_TYPES = 'artifact_types'
 FILTER_STRING = 'filter'
 ALLOWED_SOURCES = 'allowed_sources'
+NAME = 'name'
 
 
 class Config:
@@ -52,7 +53,7 @@ class Config:
         """Return a dictionary with the specified credentials"""
         for credential in self.config['credentials']:
             for key, value in credential.items():
-                if key == 'name' and value == credential_name:
+                if key == NAME and value == credential_name:
                     return credential
 
     def sources(self):
@@ -60,8 +61,7 @@ class Config:
         sources = []
 
         for source in self.config['sources']:
-            # initialize kwargs with required name argument
-            kwargs = {'name': source['name']}
+            kwargs = {}
             for key, value in source.items():
                 if key not in INTERNAL_OPTIONS:
                     kwargs[key] = value
@@ -70,11 +70,11 @@ class Config:
                     # Grab these named credentials
                     credential_name = value
                     for credential_key, credential_value in self.credentials(credential_name).items():
-                        if credential_key != 'name':
+                        if credential_key != NAME:
                             kwargs[credential_key] = credential_value
 
             # load and initialize the plugin
-            sources.append((source['name'], self._load_plugin(SOURCE, source['module']), kwargs))
+            sources.append((source[NAME], self._load_plugin(SOURCE, source['module']), kwargs))
 
         return sources
 
@@ -100,8 +100,9 @@ class Config:
                         # pass in special filter_string option
                         kwargs['filter_string'] = value
 
-                    elif key == ALLOWED_SOURCES:
-                        kwargs[key] = [s.strip() for s in value]
+                    elif key == NAME:
+                        # exclude name key from operator kwargs, since it's not used
+                        pass
 
                     else:
                         kwargs[key] = value
@@ -110,7 +111,7 @@ class Config:
                     # Grab these named credentials
                     credential_name = value
                     for credential_key, credential_value in self.credentials(credential_name).items():
-                        if credential_key != 'name':
+                        if credential_key != NAME:
                             kwargs[credential_key] = credential_value
 
             # load and initialize the plugin


### PR DESCRIPTION
Previously, we were [manually setting source names](https://github.com/InQuest/ThreatIngestor/compare/issue/48-operator-name?expand=1#diff-a03d7e3513d2593ef82c40eb0d34f695L63) from the INI section title, and there was no name key to exclude. Now that everything in the config has a name key, we need to [manually exclude it from operator loading](https://github.com/InQuest/ThreatIngestor/compare/issue/48-operator-name?expand=1#diff-a03d7e3513d2593ef82c40eb0d34f695R103) instead.

This PR fixes #48 reported by @needmorecowbell.