### PR TITLE
fix: fix a typo in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requires = requirements.strip().split('\n')
 
 extra_requirements = open(os.path.join(os.path.dirname(__file__),
             'requirements-testing.txt')).read()
-extra_requires = requirements.strip().split('\n')
+extra_requires = extra_requirements.strip().split('\n')
 
 
 setup(


### PR DESCRIPTION
The doc says that `pip install threatingestor[all]` will install all dependencies but it doesn't work as expected.
For example, `twitter>=1.17.1` isn't installed by executing `pip install threatingestor[all]`.
I think the reason is a typo in setup.py. This PR will fix the typo.