### PR TITLE
Fix an issue in RSS ingestion

### DIFF
--- a/threatingestor/sources/rss.py
+++ b/threatingestor/sources/rss.py
@@ -23,7 +23,7 @@ class Plugin(Source):
         for item in list(reversed(feed['items'])):
             # Only new items.
             published_parsed = item.get('published_parsed') or item.get('updated_parsed')
-            if published_parsed and published_parsed <= feedparser._parse_date(saved_state or '0000-00-00'):
+            if published_parsed and published_parsed <= feedparser._parse_date(saved_state or '0001-01-01'):
                 continue
 
             try:


### PR DESCRIPTION
Fix an issue in RSS ingestion (#78).

`feedparser._parse_date('0000-00-00')` returns `None` and it causes a TypeError(`'<=' not supported between instances of 'time.struct_time' and 'NoneType'`).
Using `0001-01-01` as an input instead of `0000-00-00` solves the issue.