### PR TITLE
Update MISP operator

### DIFF
--- a/tests/test_operators_misp.py
+++ b/tests/test_operators_misp.py
@@ -14,8 +14,10 @@ class TestThreatKB(unittest.TestCase):
     @patch('pymisp.ExpandedPyMISP')
     def test_tags_are_set_if_passed_in_else_default(self, ExpandedPyMISP):
         self.assertEqual(self.misp.tags, ['type:OSINT'])
-        self.assertEqual(threatingestor.operators.misp.Plugin(
-            'a', 'b', tags=['c', 'd']).tags, ['c', 'd'])
+        self.assertEqual(
+            threatingestor.operators.misp.Plugin('a', 'b', tags=['c', 'd']).tags, 
+            ['c', 'd'],
+        )
 
     def test_create_event_creates_event_and_objects(self):
         event = self.misp._create_event(

--- a/tests/test_operators_misp.py
+++ b/tests/test_operators_misp.py
@@ -87,8 +87,10 @@ class TestThreatKB(unittest.TestCase):
 
     @patch('pymisp.ExpandedPyMISP')
     def test_artifact_types_are_set_if_passed_in_else_default(self, ExpandedPyMISP):
-        artifact_types = [threatingestor.artifacts.IPAddress,
-                          threatingestor.artifacts.URL]
+        artifact_types = [
+            threatingestor.artifacts.IPAddress,
+            threatingestor.artifacts.URL,
+        ]
         self.assertEqual(threatingestor.operators.misp.Plugin(
             'a', 'b', artifact_types=artifact_types).artifact_types, artifact_types)
         self.assertEqual(threatingestor.operators.misp.Plugin('a', 'b').artifact_types, [

--- a/tests/test_operators_misp.py
+++ b/tests/test_operators_misp.py
@@ -109,5 +109,7 @@ class TestThreatKB(unittest.TestCase):
             threatingestor.operators.misp.Plugin('a', 'b', filter_string='test').filter_string, 
             'test',
         )
-        self.assertEqual(threatingestor.operators.misp.Plugin(
-            'a', 'b', allowed_sources=['test-one']).allowed_sources, ['test-one'])
+        self.assertEqual(
+            threatingestor.operators.misp.Plugin('a', 'b', allowed_sources=['test-one']).allowed_sources, 
+            ['test-one'],
+        )

--- a/tests/test_operators_misp.py
+++ b/tests/test_operators_misp.py
@@ -7,77 +7,100 @@ import threatingestor.artifacts
 
 class TestThreatKB(unittest.TestCase):
 
-    @patch('pymisp.PyMISP')
-    def setUp(self, PyMISP):
+    @patch('pymisp.ExpandedPyMISP')
+    def setUp(self, ExpandedPyMISP):
         self.misp = threatingestor.operators.misp.Plugin('a', 'b')
 
-    @patch('pymisp.PyMISP')
-    def test_tags_are_set_if_passed_in_else_default(self, PyMISP):
+    @patch('pymisp.ExpandedPyMISP')
+    def test_tags_are_set_if_passed_in_else_default(self, ExpandedPyMISP):
         self.assertEqual(self.misp.tags, ['type:OSINT'])
-        self.assertEqual(threatingestor.operators.misp.Plugin('a', 'b', tags=['c', 'd']).tags, ['c', 'd'])
+        self.assertEqual(threatingestor.operators.misp.Plugin(
+            'a', 'b', tags=['c', 'd']).tags, ['c', 'd'])
 
     def test_create_event_creates_event_and_objects(self):
-        event = self.misp._create_event(threatingestor.artifacts.Domain('test.com', 'name',
-                                        reference_link='link', reference_text='text'))
-        self.misp.api.new_event.assert_called_once_with(info=self.misp.event_info.format(source_name='name'))
-        self.misp.api.add_tag.assert_called_once_with(event, self.misp.tags[0])
-        self.misp.api.add_internal_link.assert_called_once_with(event, 'link')
-        self.misp.api.add_internal_text.assert_called_once_with(event, 'text')
-        self.misp.api.add_internal_other.assert_called_once_with(event, 'source:name')
+        event = self.misp._create_event(
+            threatingestor.artifacts.Domain(
+                'test.com',
+                'name',
+                reference_link='link',
+                reference_text='text'
+            )
+        )
+        self.misp._update_or_create_event(event)
+        self.misp.api.add_event.assert_called_once_with(event)
 
     def test_handle_domain_creates_domain(self):
-        self.misp.handle_artifact(threatingestor.artifacts.Domain('test.com', '', ''))
-        self.misp.api.new_event.assert_called_once()
-        self.misp.api.add_domain.assert_called_once_with(MOCK_ANY, 'test.com')
+        domain = threatingestor.artifacts.Domain('test.com', '', '')
+
+        event = self.misp._create_event(domain)
+        event = self.misp.handle_domain(event, domain)
+        self.assertEqual(event.Attribute[0].value, str(domain))
 
     def test_handle_hash_creates_hash(self):
-        self.misp.handle_artifact(threatingestor.artifacts.Hash('68b329da9893e34099c7d8ad5cb9c940', '', ''))
-        self.misp.api.new_event.assert_called_once()
-        self.misp.api.add_hashes.assert_called_once_with(MOCK_ANY, md5='68b329da9893e34099c7d8ad5cb9c940')
+        hash = threatingestor.artifacts.Hash(
+            '68b329da9893e34099c7d8ad5cb9c940', '', '')
+        event = self.misp._create_event(hash)
+        event = self.misp.handle_hash(event, hash)
+        self.assertEqual(event.Attribute[0].value, str(hash))
 
-        self.misp.api.reset_mock()
-        self.misp.handle_artifact(threatingestor.artifacts.Hash('adc83b19e793491b1c6ea0fd8b46cd9f32e592fc', '', ''))
-        self.misp.api.new_event.assert_called_once()
-        self.misp.api.add_hashes.assert_called_once_with(MOCK_ANY, sha1='adc83b19e793491b1c6ea0fd8b46cd9f32e592fc')
+        hash = threatingestor.artifacts.Hash(
+            'adc83b19e793491b1c6ea0fd8b46cd9f32e592fc', '', '')
+        event = self.misp._create_event(hash)
+        event = self.misp.handle_hash(event, hash)
+        self.assertEqual(event.Attribute[0].value, str(hash))
 
-        self.misp.api.reset_mock()
-        self.misp.handle_artifact(threatingestor.artifacts.Hash('01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b', '', ''))
-        self.misp.api.new_event.assert_called_once()
-        self.misp.api.add_hashes.assert_called_once_with(MOCK_ANY, sha256='01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b')
+        hash = threatingestor.artifacts.Hash(
+            '01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b', '', '')
+        event = self.misp._create_event(hash)
+        event = self.misp.handle_hash(event, hash)
+        self.assertEqual(event.Attribute[0].value, str(hash))
 
-        self.misp.api.reset_mock()
-        self.misp.handle_artifact(threatingestor.artifacts.Hash('invalid', '', ''))
-        self.misp.api.new_event.assert_not_called()
-        self.misp.api.add_hashes.assert_not_called()
+        hash = threatingestor.artifacts.Hash('invalid', '', '')
+        event = self.misp._create_event(hash)
+        event = self.misp.handle_hash(event, hash)
+        self.assertEqual(event.Attribute, [])
 
     def test_handle_ipaddress_creates_ipaddress(self):
-        self.misp.handle_artifact(threatingestor.artifacts.IPAddress('123.123.123.123', '', ''))
-        self.misp.api.new_event.assert_called_once()
-        self.misp.api.add_ipdst.assert_called_once_with(MOCK_ANY, '123.123.123.123')
+        ipaddress = threatingestor.artifacts.IPAddress(
+            '123.123.123.123', '', '')
+        event = self.misp._create_event(ipaddress)
+        event = self.misp.handle_ipaddress(event, ipaddress)
+        self.assertEqual(event.Attribute[0].value, str(ipaddress))
 
     def test_handle_url_creates_url(self):
-        self.misp.handle_artifact(threatingestor.artifacts.URL('http://example.com', '', ''))
-        self.misp.api.new_event.assert_called_once()
-        self.misp.api.add_url.assert_called_once_with(MOCK_ANY, 'http://example.com')
+        url = threatingestor.artifacts.URL('http://example.com', '', '')
+        event = self.misp._create_event(url)
+        event = self.misp.handle_url(event, url)
+        self.assertEqual(event.Attribute[0].value, str(url))
 
     def test_handle_yarasignature_creates_yarasignature(self):
-        self.misp.handle_artifact(threatingestor.artifacts.YARASignature('test', '', ''))
-        self.misp.api.new_event.assert_called_once()
-        self.misp.api.add_yara.assert_called_once_with(MOCK_ANY, 'test')
+        yara = threatingestor.artifacts.YARASignature('test', '', '')
+        event = self.misp._create_event(yara)
+        event = self.misp.handle_yarasignature(event, yara)
+        self.assertEqual(event.Attribute[0].value, str(yara))
 
-    @patch('pymisp.PyMISP')
-    def test_artifact_types_are_set_if_passed_in_else_default(self, PyMISP):
-        artifact_types = [threatingestor.artifacts.IPAddress, threatingestor.artifacts.URL]
-        self.assertEqual(threatingestor.operators.misp.Plugin('a', 'b', artifact_types=artifact_types).artifact_types, artifact_types)
+    def test_handle_artifact_creates_event(self):
+        artifact = threatingestor.artifacts.URL('http://example.com', '', '')
+        event = self.misp.handle_artifact(artifact)
+        self.misp.api.add_event.assert_called_once()
+
+    @patch('pymisp.ExpandedPyMISP')
+    def test_artifact_types_are_set_if_passed_in_else_default(self, ExpandedPyMISP):
+        artifact_types = [threatingestor.artifacts.IPAddress,
+                          threatingestor.artifacts.URL]
+        self.assertEqual(threatingestor.operators.misp.Plugin(
+            'a', 'b', artifact_types=artifact_types).artifact_types, artifact_types)
         self.assertEqual(threatingestor.operators.misp.Plugin('a', 'b').artifact_types, [
-                threatingestor.artifacts.Domain,
-                threatingestor.artifacts.Hash,
-                threatingestor.artifacts.IPAddress,
-                threatingestor.artifacts.URL,
-                threatingestor.artifacts.YARASignature
+            threatingestor.artifacts.Domain,
+            threatingestor.artifacts.Hash,
+            threatingestor.artifacts.IPAddress,
+            threatingestor.artifacts.URL,
+            threatingestor.artifacts.YARASignature
         ])
 
-    @patch('pymisp.PyMISP')
-    def test_filter_string_and_allowed_sources_are_set_if_passed_in(self, PyMISP):
-        self.assertEqual(threatingestor.operators.misp.Plugin('a', 'b', filter_string='test').filter_string, 'test')
-        self.assertEqual(threatingestor.operators.misp.Plugin('a', 'b', allowed_sources=['test-one']).allowed_sources, ['test-one'])
+    @patch('pymisp.ExpandedPyMISP')
+    def test_filter_string_and_allowed_sources_are_set_if_passed_in(self, ExpandedPyMISP):
+        self.assertEqual(threatingestor.operators.misp.Plugin(
+            'a', 'b', filter_string='test').filter_string, 'test')
+        self.assertEqual(threatingestor.operators.misp.Plugin(
+            'a', 'b', allowed_sources=['test-one']).allowed_sources, ['test-one'])

--- a/tests/test_operators_misp.py
+++ b/tests/test_operators_misp.py
@@ -91,8 +91,10 @@ class TestThreatKB(unittest.TestCase):
             threatingestor.artifacts.IPAddress,
             threatingestor.artifacts.URL,
         ]
-        self.assertEqual(threatingestor.operators.misp.Plugin(
-            'a', 'b', artifact_types=artifact_types).artifact_types, artifact_types)
+        self.assertEqual(
+            threatingestor.operators.misp.Plugin( 'a', 'b', artifact_types=artifact_types).artifact_types, 
+            artifact_types,
+        )
         self.assertEqual(threatingestor.operators.misp.Plugin('a', 'b').artifact_types, [
             threatingestor.artifacts.Domain,
             threatingestor.artifacts.Hash,

--- a/tests/test_operators_misp.py
+++ b/tests/test_operators_misp.py
@@ -25,7 +25,7 @@ class TestThreatKB(unittest.TestCase):
                 'test.com',
                 'name',
                 reference_link='link',
-                reference_text='text'
+                reference_text='text',
             )
         )
         self.misp._update_or_create_event(event)

--- a/tests/test_operators_misp.py
+++ b/tests/test_operators_misp.py
@@ -15,7 +15,7 @@ class TestThreatKB(unittest.TestCase):
     def test_tags_are_set_if_passed_in_else_default(self, ExpandedPyMISP):
         self.assertEqual(self.misp.tags, ['type:OSINT'])
         self.assertEqual(
-            threatingestor.operators.misp.Plugin('a', 'b', tags=['c', 'd']).tags, 
+            threatingestor.operators.misp.Plugin('a', 'b', tags=['c', 'd']).tags,
             ['c', 'd'],
         )
 
@@ -35,49 +35,49 @@ class TestThreatKB(unittest.TestCase):
         domain = threatingestor.artifacts.Domain('test.com', '', '')
 
         event = self.misp._create_event(domain)
-        event = self.misp.handle_domain(event, domain)
+        event = self.misp.handle_domain(domain, event)
         self.assertEqual(event.Attribute[0].value, str(domain))
 
     def test_handle_hash_creates_hash(self):
         hash = threatingestor.artifacts.Hash(
             '68b329da9893e34099c7d8ad5cb9c940', '', '')
         event = self.misp._create_event(hash)
-        event = self.misp.handle_hash(event, hash)
+        event = self.misp.handle_hash(hash, event)
         self.assertEqual(event.Attribute[0].value, str(hash))
 
         hash = threatingestor.artifacts.Hash(
             'adc83b19e793491b1c6ea0fd8b46cd9f32e592fc', '', '')
         event = self.misp._create_event(hash)
-        event = self.misp.handle_hash(event, hash)
+        event = self.misp.handle_hash(hash, event)
         self.assertEqual(event.Attribute[0].value, str(hash))
 
         hash = threatingestor.artifacts.Hash(
             '01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b', '', '')
         event = self.misp._create_event(hash)
-        event = self.misp.handle_hash(event, hash)
+        event = self.misp.handle_hash(hash, event)
         self.assertEqual(event.Attribute[0].value, str(hash))
 
         hash = threatingestor.artifacts.Hash('invalid', '', '')
         event = self.misp._create_event(hash)
-        event = self.misp.handle_hash(event, hash)
+        event = self.misp.handle_hash(hash, event)
         self.assertEqual(event.Attribute, [])
 
     def test_handle_ipaddress_creates_ipaddress(self):
         ipaddress = threatingestor.artifacts.IPAddress('123.123.123.123', '', '')
         event = self.misp._create_event(ipaddress)
-        event = self.misp.handle_ipaddress(event, ipaddress)
+        event = self.misp.handle_ipaddress(ipaddress, event)
         self.assertEqual(event.Attribute[0].value, str(ipaddress))
 
     def test_handle_url_creates_url(self):
         url = threatingestor.artifacts.URL('http://example.com', '', '')
         event = self.misp._create_event(url)
-        event = self.misp.handle_url(event, url)
+        event = self.misp.handle_url(url, event)
         self.assertEqual(event.Attribute[0].value, str(url))
 
     def test_handle_yarasignature_creates_yarasignature(self):
         yara = threatingestor.artifacts.YARASignature('test', '', '')
         event = self.misp._create_event(yara)
-        event = self.misp.handle_yarasignature(event, yara)
+        event = self.misp.handle_yarasignature(yara, event)
         self.assertEqual(event.Attribute[0].value, str(yara))
 
     def test_handle_artifact_creates_event(self):
@@ -92,7 +92,7 @@ class TestThreatKB(unittest.TestCase):
             threatingestor.artifacts.URL,
         ]
         self.assertEqual(
-            threatingestor.operators.misp.Plugin('a', 'b', artifact_types=artifact_types).artifact_types, 
+            threatingestor.operators.misp.Plugin('a', 'b', artifact_types=artifact_types).artifact_types,
             artifact_types,
         )
         self.assertEqual(threatingestor.operators.misp.Plugin('a', 'b').artifact_types, [
@@ -106,10 +106,10 @@ class TestThreatKB(unittest.TestCase):
     @patch('pymisp.ExpandedPyMISP')
     def test_filter_string_and_allowed_sources_are_set_if_passed_in(self, ExpandedPyMISP):
         self.assertEqual(
-            threatingestor.operators.misp.Plugin('a', 'b', filter_string='test').filter_string, 
+            threatingestor.operators.misp.Plugin('a', 'b', filter_string='test').filter_string,
             'test',
         )
         self.assertEqual(
-            threatingestor.operators.misp.Plugin('a', 'b', allowed_sources=['test-one']).allowed_sources, 
+            threatingestor.operators.misp.Plugin('a', 'b', allowed_sources=['test-one']).allowed_sources,
             ['test-one'],
         )

--- a/tests/test_operators_misp.py
+++ b/tests/test_operators_misp.py
@@ -92,7 +92,7 @@ class TestThreatKB(unittest.TestCase):
             threatingestor.artifacts.URL,
         ]
         self.assertEqual(
-            threatingestor.operators.misp.Plugin( 'a', 'b', artifact_types=artifact_types).artifact_types, 
+            threatingestor.operators.misp.Plugin('a', 'b', artifact_types=artifact_types).artifact_types, 
             artifact_types,
         )
         self.assertEqual(threatingestor.operators.misp.Plugin('a', 'b').artifact_types, [

--- a/tests/test_operators_misp.py
+++ b/tests/test_operators_misp.py
@@ -105,7 +105,9 @@ class TestThreatKB(unittest.TestCase):
 
     @patch('pymisp.ExpandedPyMISP')
     def test_filter_string_and_allowed_sources_are_set_if_passed_in(self, ExpandedPyMISP):
-        self.assertEqual(threatingestor.operators.misp.Plugin(
-            'a', 'b', filter_string='test').filter_string, 'test')
+        self.assertEqual(
+            threatingestor.operators.misp.Plugin('a', 'b', filter_string='test').filter_string, 
+            'test',
+        )
         self.assertEqual(threatingestor.operators.misp.Plugin(
             'a', 'b', allowed_sources=['test-one']).allowed_sources, ['test-one'])

--- a/tests/test_operators_misp.py
+++ b/tests/test_operators_misp.py
@@ -63,8 +63,7 @@ class TestThreatKB(unittest.TestCase):
         self.assertEqual(event.Attribute, [])
 
     def test_handle_ipaddress_creates_ipaddress(self):
-        ipaddress = threatingestor.artifacts.IPAddress(
-            '123.123.123.123', '', '')
+        ipaddress = threatingestor.artifacts.IPAddress('123.123.123.123', '', '')
         event = self.misp._create_event(ipaddress)
         event = self.misp.handle_ipaddress(event, ipaddress)
         self.assertEqual(event.Attribute[0].value, str(ipaddress))

--- a/threatingestor/operators/misp.py
+++ b/threatingestor/operators/misp.py
@@ -10,7 +10,8 @@ try:
     import pymisp
 except ImportError:
     raise DependencyError(
-        "Dependency PyMISP required for MISP operator is not installed")
+        "Dependency PyMISP required for MISP operator is not installed"
+    )
 
 
 class Plugin(Operator):

--- a/threatingestor/operators/misp.py
+++ b/threatingestor/operators/misp.py
@@ -48,7 +48,7 @@ class Plugin(Operator):
         elif isinstance(artifact, threatingestor.artifacts.IPAddress):
             event = self.handle_ipaddress(artifact, event=event)
         if isinstance(artifact, threatingestor.artifacts.URL):
-            event = self.handle_url(artifact, event = event)
+            event = self.handle_url(artifact, event=event)
         elif isinstance(artifact, threatingestor.artifacts.YARASignature):
             event = self.handle_yarasignature(artifact, event = event)
 

--- a/threatingestor/operators/misp.py
+++ b/threatingestor/operators/misp.py
@@ -44,7 +44,7 @@ class Plugin(Operator):
         if isinstance(artifact, threatingestor.artifacts.Hash):
             event = self.handle_hash(event, artifact)
         elif isinstance(artifact, threatingestor.artifacts.IPAddress):
-            eveng = self.handle_ipaddress(event, artifact)
+            event = self.handle_ipaddress(event, artifact)
         if isinstance(artifact, threatingestor.artifacts.URL):
             event = self.handle_url(event, artifact)
         elif isinstance(artifact, threatingestor.artifacts.YARASignature):

--- a/threatingestor/operators/misp.py
+++ b/threatingestor/operators/misp.py
@@ -46,7 +46,7 @@ class Plugin(Operator):
         if isinstance(artifact, threatingestor.artifacts.Hash):
             event = self.handle_hash(artifact, event=event)
         elif isinstance(artifact, threatingestor.artifacts.IPAddress):
-            event = self.handle_ipaddress(artifact, event = event)
+            event = self.handle_ipaddress(artifact, event=event)
         if isinstance(artifact, threatingestor.artifacts.URL):
             event = self.handle_url(artifact, event = event)
         elif isinstance(artifact, threatingestor.artifacts.YARASignature):

--- a/threatingestor/operators/misp.py
+++ b/threatingestor/operators/misp.py
@@ -9,21 +9,24 @@ from threatingestor.exceptions import DependencyError
 try:
     import pymisp
 except ImportError:
-    raise DependencyError("Dependency PyMISP required for MISP operator is not installed")
+    raise DependencyError(
+        "Dependency PyMISP required for MISP operator is not installed")
 
 
 class Plugin(Operator):
     """Operator for MISP."""
+
     def __init__(self, url, key, ssl=True, tags=None, artifact_types=None, filter_string=None, allowed_sources=None):
         """MISP operator."""
-        self.api = pymisp.PyMISP(url, key, ssl, 'json')
+        self.api = pymisp.ExpandedPyMISP(url, key, ssl)
         if tags:
             self.tags = tags
         else:
             self.tags = ['type:OSINT']
         self.event_info = 'ThreatIngestor Event: {source_name}'
 
-        super(Plugin, self).__init__(artifact_types, filter_string, allowed_sources)
+        super(Plugin, self).__init__(
+            artifact_types, filter_string, allowed_sources)
         self.artifact_types = artifact_types or [
             threatingestor.artifacts.Domain,
             threatingestor.artifacts.Hash,
@@ -32,69 +35,102 @@ class Plugin(Operator):
             threatingestor.artifacts.YARASignature,
         ]
 
-
     def handle_artifact(self, artifact):
         """Operate on a single artifact."""
-        if isinstance(artifact, threatingestor.artifacts.Domain):
-            self.handle_domain(artifact)
-        if isinstance(artifact, threatingestor.artifacts.Hash):
-            self.handle_hash(artifact)
-        elif isinstance(artifact, threatingestor.artifacts.IPAddress):
-            self.handle_ipaddress(artifact)
-        if isinstance(artifact, threatingestor.artifacts.URL):
-            self.handle_url(artifact)
-        elif isinstance(artifact, threatingestor.artifacts.YARASignature):
-            self.handle_yarasignature(artifact)
+        event = self._find_or_create_event(artifact)
 
+        if isinstance(artifact, threatingestor.artifacts.Domain):
+            event = self.handle_domain(event, artifact)
+        if isinstance(artifact, threatingestor.artifacts.Hash):
+            event = self.handle_hash(event, artifact)
+        elif isinstance(artifact, threatingestor.artifacts.IPAddress):
+            eveng = self.handle_ipaddress(event, artifact)
+        if isinstance(artifact, threatingestor.artifacts.URL):
+            event = self.handle_url(event, artifact)
+        elif isinstance(artifact, threatingestor.artifacts.YARASignature):
+            event = self.handle_yarasignature(event, artifact)
+
+        self._update_or_create_event(event)
+
+    def _update_or_create_event(self, event):
+        """Update or create an event for the artifact."""
+        event_dict = event.to_dict()
+        attributes = event_dict.get("Attribute", [])
+        if len(attributes) == 0:
+            return
+
+        if event_dict.get("uuid") is None:
+            self.api.add_event(event)
+        else:
+            self.api.update_event(event)
+
+    def _find_or_create_event(self, artifact):
+        """Find or create an event for the artifact."""
+        event = self._find_event(artifact)
+        if event is not None:
+            return event
+
+        return self._create_event(artifact)
+
+    def _find_event(self, artifact):
+        """Find an event which has the same refetrence link, return an Event object."""
+        events = self.api.search(
+            "events",
+            limit=1,
+            type_attribute="link",
+            value=artifact.reference_link,
+            pythonify=True
+        )
+        if len(events) == 1:
+            return events[0]
+
+        return None
 
     def _create_event(self, artifact):
         """Create an event in MISP, return an Event object."""
-        event = self.api.new_event(info=self.event_info.format(
-            source_name=artifact.source_name))
+        event = pymisp.MISPEvent()
+        event.info = self.event_info.format(source_name=artifact.source_name)
 
         # Add tags.
         for tag in self.tags:
-            self.api.add_tag(event, tag)
+            event.add_tag(tag)
 
         # Add references.
-        self.api.add_internal_link(event, artifact.reference_link)
-        self.api.add_internal_text(event, artifact.reference_text)
-        self.api.add_internal_other(event, f'source:{artifact.source_name}')
+        if artifact.reference_link != "":
+            event.add_attribute("link", artifact.reference_link)
+        if artifact.reference_text != "":
+            event.add_attribute("text", artifact.reference_text)
+        if artifact.source_name != "":
+            event.add_attribute("other",  f'source:{artifact.source_name}')
 
         return event
 
-
-    def handle_domain(self, domain):
+    def handle_domain(self, event, domain):
         """Handle a single domain."""
-        event = self._create_event(domain)
-        self.api.add_domain(event, str(domain))
+        event.add_attribute("domain", str(domain))
+        return event
 
-    def handle_hash(self, hash_):
+    def handle_hash(self, event, hash_):
         """Handle a single hash."""
         if hash_.hash_type() == hash_.MD5:
-            event = self._create_event(hash_)
-            self.api.add_hashes(event, md5=str(hash_))
+            event.add_attribute("md5", str(hash_))
         elif hash_.hash_type() == hash_.SHA1:
-            event = self._create_event(hash_)
-            self.api.add_hashes(event, sha1=str(hash_))
+            event.add_attribute("sha1", str(hash_))
         elif hash_.hash_type() == hash_.SHA256:
-            event = self._create_event(hash_)
-            self.api.add_hashes(event, sha256=str(hash_))
+            event.add_attribute("sha256", str(hash_))
+        return event
 
-
-    def handle_ipaddress(self, ipaddress):
+    def handle_ipaddress(self, event, ipaddress):
         """Handle a single IP address."""
-        event = self._create_event(ipaddress)
-        self.api.add_ipdst(event, str(ipaddress))
+        event.add_attribute("ip-dst", str(ipaddress))
+        return event
 
-
-    def handle_url(self, url):
+    def handle_url(self, event, url):
         """Handle a single URL."""
-        event = self._create_event(url)
-        self.api.add_url(event, str(url))
+        event.add_attribute("url", str(url))
+        return event
 
-
-    def handle_yarasignature(self, yarasignature):
+    def handle_yarasignature(self, event, yarasignature):
         """Handle a single YARA signature."""
-        event = self._create_event(yarasignature)
-        self.api.add_yara(event, str(yarasignature))
+        event.add_attribute("yara", str(yarasignature))
+        return event

--- a/threatingestor/operators/misp.py
+++ b/threatingestor/operators/misp.py
@@ -44,7 +44,7 @@ class Plugin(Operator):
         if isinstance(artifact, threatingestor.artifacts.Domain):
             event = self.handle_domain(artifact, event=event)
         if isinstance(artifact, threatingestor.artifacts.Hash):
-            event = self.handle_hash(artifact, event = event)
+            event = self.handle_hash(artifact, event=event)
         elif isinstance(artifact, threatingestor.artifacts.IPAddress):
             event = self.handle_ipaddress(artifact, event = event)
         if isinstance(artifact, threatingestor.artifacts.URL):

--- a/threatingestor/operators/misp.py
+++ b/threatingestor/operators/misp.py
@@ -42,7 +42,7 @@ class Plugin(Operator):
         event = self._find_or_create_event(artifact)
 
         if isinstance(artifact, threatingestor.artifacts.Domain):
-            event = self.handle_domain(artifact, event = event)
+            event = self.handle_domain(artifact, event=event)
         if isinstance(artifact, threatingestor.artifacts.Hash):
             event = self.handle_hash(artifact, event = event)
         elif isinstance(artifact, threatingestor.artifacts.IPAddress):

--- a/threatingestor/operators/misp.py
+++ b/threatingestor/operators/misp.py
@@ -58,7 +58,7 @@ class Plugin(Operator):
         """Update or create an event for the artifact."""
         event_dict = event.to_dict()
         attributes = event_dict.get("Attribute", [])
-        if len(attributes) == 0:
+        if not attributes:
             return
 
         if event_dict.get("uuid") is None:

--- a/threatingestor/operators/misp.py
+++ b/threatingestor/operators/misp.py
@@ -27,7 +27,8 @@ class Plugin(Operator):
         self.event_info = 'ThreatIngestor Event: {source_name}'
 
         super(Plugin, self).__init__(
-            artifact_types, filter_string, allowed_sources)
+            artifact_types, filter_string, allowed_sources
+        )
         self.artifact_types = artifact_types or [
             threatingestor.artifacts.Domain,
             threatingestor.artifacts.Hash,

--- a/threatingestor/operators/misp.py
+++ b/threatingestor/operators/misp.py
@@ -50,7 +50,7 @@ class Plugin(Operator):
         if isinstance(artifact, threatingestor.artifacts.URL):
             event = self.handle_url(artifact, event=event)
         elif isinstance(artifact, threatingestor.artifacts.YARASignature):
-            event = self.handle_yarasignature(artifact, event = event)
+            event = self.handle_yarasignature(artifact, event=event)
 
         self._update_or_create_event(event)
 

--- a/threatingestor/operators/misp.py
+++ b/threatingestor/operators/misp.py
@@ -42,15 +42,15 @@ class Plugin(Operator):
         event = self._find_or_create_event(artifact)
 
         if isinstance(artifact, threatingestor.artifacts.Domain):
-            event = self.handle_domain(event, artifact)
+            event = self.handle_domain(artifact, event = event)
         if isinstance(artifact, threatingestor.artifacts.Hash):
-            event = self.handle_hash(event, artifact)
+            event = self.handle_hash(artifact, event = event)
         elif isinstance(artifact, threatingestor.artifacts.IPAddress):
-            event = self.handle_ipaddress(event, artifact)
+            event = self.handle_ipaddress(artifact, event = event)
         if isinstance(artifact, threatingestor.artifacts.URL):
-            event = self.handle_url(event, artifact)
+            event = self.handle_url(artifact, event = event)
         elif isinstance(artifact, threatingestor.artifacts.YARASignature):
-            event = self.handle_yarasignature(event, artifact)
+            event = self.handle_yarasignature(artifact, event = event)
 
         self._update_or_create_event(event)
 
@@ -60,8 +60,8 @@ class Plugin(Operator):
         attributes = event_dict.get("Attribute", [])
         if not attributes:
             return
-
-        if event_dict.get("uuid") is None:
+        # If an event doesn't have "date" field, it is not created int MISP
+        if event_dict.get("date") is None:
             self.api.add_event(event)
         else:
             self.api.update_event(event)
@@ -107,12 +107,12 @@ class Plugin(Operator):
 
         return event
 
-    def handle_domain(self, event, domain):
+    def handle_domain(self, domain, event: pymisp.MISPEvent):
         """Handle a single domain."""
         event.add_attribute("domain", str(domain))
         return event
 
-    def handle_hash(self, event, hash_):
+    def handle_hash(self, hash_, event: pymisp.MISPEvent):
         """Handle a single hash."""
         if hash_.hash_type() == hash_.MD5:
             event.add_attribute("md5", str(hash_))
@@ -122,17 +122,17 @@ class Plugin(Operator):
             event.add_attribute("sha256", str(hash_))
         return event
 
-    def handle_ipaddress(self, event, ipaddress):
+    def handle_ipaddress(self, ipaddress, event: pymisp.MISPEvent):
         """Handle a single IP address."""
         event.add_attribute("ip-dst", str(ipaddress))
         return event
 
-    def handle_url(self, event, url):
+    def handle_url(self, url, event: pymisp.MISPEvent):
         """Handle a single URL."""
         event.add_attribute("url", str(url))
         return event
 
-    def handle_yarasignature(self, event, yarasignature):
+    def handle_yarasignature(self, yarasignature, event: pymisp.MISPEvent):
         """Handle a single YARA signature."""
         event.add_attribute("yara", str(yarasignature))
         return event


### PR DESCRIPTION
This PR contains two changes in MISP operator.

### 1. Catching up to the latest PyMISP.

Remove deprecated / deleted methods and use `ExpandedPyMISP` to catch up the latest PyMISP.

### 2. Grouping attributes by a reference link

Current MISP operator implementation creates an event per an attribute.
IMO it's useful to create an event per a reference link. It means that if there is an event which has the same reference link, add an attribute(artifact) to that event.