### PR TITLE
Follow Pastebin links module.

### DIFF
--- a/threatingestor/sources/twitter_follow_links.py
+++ b/threatingestor/sources/twitter_follow_links.py
@@ -81,21 +81,23 @@ class Plugin(Source):
             for url in tweet['entities'].get('urls', []):
                 try:
                     tweet['content'] = tweet['content'].replace(url['url'], url['expanded_url'])
+
+                    # Check if pastebin.com in url
                     if re.search(WHITELIST_DOMAINS, url['expanded_url']):
 
+                        # Check if the url is already returning the 'raw' pastebin. If not, update the url
                         if 'raw' not in url['expanded_url']:
                             pastebin_id = re.search(r"pastebin.com/(.*?)$", url['expanded_url']).group(1)
                             location = f"https://pastebin.com/raw/{pastebin_id}"
                         else:
                             location = url['expanded_url']
+
                         req = requests.get(location)
+                        saved_state = tweet['id']
                         artifacts += self.process_element(req.text, location, include_nonobfuscated=True)
 
                         logger.log('NOTIFY', f"Discovered paste: {location}")
 
-                    # else:
-                        # logger.info(f"Did not match paste: {url['expanded_url']}")
-                        # print(url['expanded_url'])
                 except KeyError:
                     # No url/expanded_url, continue without expanding.
                     pass

--- a/threatingestor/sources/twitter_follow_links.py
+++ b/threatingestor/sources/twitter_follow_links.py
@@ -40,12 +40,10 @@ class Plugin(Source):
         self.endpoint = self.api.statuses.mentions_timeline
         if (kwargs.get('slug') and kwargs.get('owner_screen_name')) or (kwargs.get('list_id') and kwargs.get('owner_screen_name')):
             self.endpoint = self.api.lists.statuses
-        # elif kwargs.get('slug') and kwargs.get('owner_screen_name')
         elif kwargs.get('screen_name') or kwargs.get('user_id'):
             self.endpoint = self.api.statuses.user_timeline
         elif kwargs.get('q'):
             self.endpoint = self.api.search.tweets
-
 
     def run(self, saved_state):
         # Modify kwargs to insert since_id.
@@ -85,7 +83,6 @@ class Plugin(Source):
                     tweet['content'] = tweet['content'].replace(url['url'], url['expanded_url'])
                     if re.search(WHITELIST_DOMAINS, url['expanded_url']):
 
-
                         contains_raw = re.search(r"/raw/", url['expanded_url'])
                         if not contains_raw:
                             pastebin_id = re.search(r"pastebin.com/(.*?)$", url['expanded_url']).group(1)
@@ -97,8 +94,8 @@ class Plugin(Source):
 
                         logger.log('NOTIFY', f"Discovered paste: {location}")
 
-                    else:
-                        logger.info(f"Did not match paste: {url['expanded_url']}")
+                    # else:
+                        # logger.info(f"Did not match paste: {url['expanded_url']}")
                         # print(url['expanded_url'])
                 except KeyError:
                     # No url/expanded_url, continue without expanding.

--- a/threatingestor/sources/twitter_follow_links.py
+++ b/threatingestor/sources/twitter_follow_links.py
@@ -6,9 +6,13 @@ from loguru import logger
 
 
 from threatingestor.sources import Source
+import requests
+import re
 
 
 TWEET_URL = 'https://twitter.com/{user}/status/{id}'
+
+WHITELIST_DOMAINS = r"pastebin\.com"
 
 
 class Plugin(Source):
@@ -36,6 +40,7 @@ class Plugin(Source):
         self.endpoint = self.api.statuses.mentions_timeline
         if (kwargs.get('slug') and kwargs.get('owner_screen_name')) or (kwargs.get('list_id') and kwargs.get('owner_screen_name')):
             self.endpoint = self.api.lists.statuses
+        # elif kwargs.get('slug') and kwargs.get('owner_screen_name')
         elif kwargs.get('screen_name') or kwargs.get('user_id'):
             self.endpoint = self.api.statuses.user_timeline
         elif kwargs.get('q'):
@@ -73,18 +78,34 @@ class Plugin(Source):
         # Traverse in reverse, old to new.
         tweets.reverse()
         for tweet in tweets:
+
             # Expand t.co links.
             for url in tweet['entities'].get('urls', []):
                 try:
                     tweet['content'] = tweet['content'].replace(url['url'], url['expanded_url'])
+                    if re.search(WHITELIST_DOMAINS, url['expanded_url']):
+
+
+                        contains_raw = re.search(r"/raw/", url['expanded_url'])
+                        if not contains_raw:
+                            pastebin_id = re.search(r"pastebin.com/(.*?)$", url['expanded_url']).group(1)
+                            location = f"https://pastebin.com/raw/{pastebin_id}"
+                        else:
+                            location = url['expanded_url']
+                        req = requests.get(location)
+                        artifacts += self.process_element(req.text, location, include_nonobfuscated=True)
+
+                        logger.log('NOTIFY', f"Discovered paste: {location}")
+
+                    else:
+                        logger.info(f"Did not match paste: {url['expanded_url']}")
+                        # print(url['expanded_url'])
                 except KeyError:
                     # No url/expanded_url, continue without expanding.
                     pass
 
-            # Process tweet.
-            saved_state = tweet['id']
-            artifacts += self.process_element(tweet['content'],
-                                              TWEET_URL.format(user=tweet['user'], id=tweet['id']),
-                                              include_nonobfuscated=self.include_nonobfuscated)
-
         return saved_state, artifacts
+
+
+
+

--- a/threatingestor/sources/twitter_follow_links.py
+++ b/threatingestor/sources/twitter_follow_links.py
@@ -83,8 +83,7 @@ class Plugin(Source):
                     tweet['content'] = tweet['content'].replace(url['url'], url['expanded_url'])
                     if re.search(WHITELIST_DOMAINS, url['expanded_url']):
 
-                        contains_raw = re.search(r"/raw/", url['expanded_url'])
-                        if not contains_raw:
+                        if 'raw' not in url['expanded_url']:
                             pastebin_id = re.search(r"pastebin.com/(.*?)$", url['expanded_url']).group(1)
                             location = f"https://pastebin.com/raw/{pastebin_id}"
                         else:

--- a/threatingestor/sources/twitter_follow_links.py
+++ b/threatingestor/sources/twitter_follow_links.py
@@ -1,13 +1,11 @@
 from __future__ import absolute_import
 
 
+import re
+import requests
 import twitter
 from loguru import logger
-
-
 from threatingestor.sources import Source
-import requests
-import re
 
 
 TWEET_URL = 'https://twitter.com/{user}/status/{id}'


### PR DESCRIPTION
Added module to follow and extract IOC's from Pastebin links embedded in tweets as per issue #97 
This works very similarly to the Twitter module and goes off of search, lists, users, etc.

I also updated the Twitter module to support `list_id` as not all lists have an associated slug.
https://developer.twitter.com/en/docs/twitter-api/v1/accounts-and-users/create-manage-lists/api-reference/get-lists-statuses

