### PR TITLE
add type check for extra_requires on lines 16-18

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,9 @@ requires = requirements.strip().split('\n')
 extra_requirements = open(os.path.join(os.path.dirname(__file__),
             'requirements-testing.txt')).read()
 extra_requires = extra_requirements.strip().split('\n')
+if not isinstance(extra_requires, list):
+    print("requirements-testing.txt was not parsed correctly.")
+    extra_requires = []
 
 
 setup(


### PR DESCRIPTION
Fix for the following issue:
`Setup fails: 'extras_require' must be a dictionary #100`
Adds a type check for a parsed requirements file. If the parsed file does not produce a list, an empty list will be created in its place, and a message printed to the console.