### PR TITLE
Retrieve all content of a retweeted tweet

### DIFF
--- a/threatingestor/sources/twitter.py
+++ b/threatingestor/sources/twitter.py
@@ -62,12 +62,19 @@ class Plugin(Source):
         except TypeError:
             tweet_list = response
 
-        tweets = [{
-            'content': s.get('full_text', ''),
-            'id': s.get('id_str', ''),
-            'user': s.get('user', {}).get('screen_name', ''),
-            'entities': s.get('entities', {}),
-        } for s in tweet_list]
+        tweets = []
+        for tweet in tweet_list:
+            if "retweeted_status" in tweet:
+                content = tweet['retweeted_status'].get('full_text', '')
+            else:
+                content = tweet.get('full_text', '')
+
+            tweets.append({
+                'content': content,
+                'id': tweet.get('id_str', ''),
+                'user': tweet.get('user', {}).get('screen_name', ''),
+                'entities': tweet.get('entities', {}),
+            })
 
         artifacts = []
         # Traverse in reverse, old to new.


### PR DESCRIPTION
Not all the content of a tweet is extracted if it is a retweeted one.
Thus, in the related structure of a tweet might exists a extra section named "retweed_status" that contains all body of this tweet.